### PR TITLE
Hide API Key in app-env

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -23,4 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 # env
-# app-env
+app-env

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# env
+# app-env

--- a/client/app-env
+++ b/client/app-env
@@ -1,0 +1,1 @@
+export MAPS_API="YOUR_MAPS_API_KEY"

--- a/client/src/components/MapView.js
+++ b/client/src/components/MapView.js
@@ -51,7 +51,7 @@ class MapView extends Component {
       return (
         <div style={{ height: '50vh', width: '100%', padding: '3%'}}>
           <GoogleMapReact
-            bootstrapURLKeys={{ key: 'AIzaSyDzHP_MAk5Kq9u_eW5zuoBDvPd1GEfjWKY' }}
+            bootstrapURLKeys={{ key: process.env.MAPS_API }}
             defaultZoom={this.props.zoom}
             center={[Restaurant.latitude, Restaurant.longitude]}
           >


### PR DESCRIPTION
To add Maps API key:
- Open **client/src/app-env**
- Replace `YOUR_MAPS_API_KEY` with key

**app-env** is in **.gitignore**, so the key will never be pushed to repo.
*NOTE: Map will say "This page can't load Google Maps correctly." because the key is not directly in MapView.js code.*